### PR TITLE
Update go.thebigfile.com/coreutils to v0.0.9 and go.thebigfile.com/co…

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -41,14 +41,14 @@ func (ms *memState) Sync(t *testing.T, cm *chain.Manager) {
 			}
 
 			// revert utxos
-			for _, sced := range cru.BigFileElementDiffs() {
-				sce := &sced.BigFileElement
-				if sce.BigFileOutput.Address == types.AnyoneCanSpend().Address() {
-					if sced.Spent {
-						ms.utxos[sce.ID] = sce.Copy()
+			for _, biged := range cru.BigFileElementDiffs() {
+				bige := &biged.BigFileElement
+				if bige.BigFileOutput.Address == types.AnyoneCanSpend().Address() {
+					if biged.Spent {
+						ms.utxos[bige.ID] = bige.Copy()
 					}
-					if sced.Created {
-						delete(ms.utxos, sce.ID)
+					if biged.Created {
+						delete(ms.utxos, bige.ID)
 					}
 				}
 			}
@@ -70,14 +70,14 @@ func (ms *memState) Sync(t *testing.T, cm *chain.Manager) {
 			ms.chainIndexElements = append(ms.chainIndexElements, cau.ChainIndexElement())
 
 			// apply utxos
-			for _, sced := range cau.BigFileElementDiffs() {
-				sce := &sced.BigFileElement
-				if sce.BigFileOutput.Address == types.AnyoneCanSpend().Address() {
-					if sced.Created {
-						ms.utxos[sce.ID] = sce.Copy()
+			for _, biged := range cau.BigFileElementDiffs() {
+				bige := &biged.BigFileElement
+				if bige.BigFileOutput.Address == types.AnyoneCanSpend().Address() {
+					if biged.Created {
+						ms.utxos[bige.ID] = bige.Copy()
 					}
-					if sced.Spent {
-						delete(ms.utxos, sce.ID)
+					if biged.Spent {
+						delete(ms.utxos, bige.ID)
 					}
 				}
 			}

--- a/chain/db.go
+++ b/chain/db.go
@@ -545,17 +545,17 @@ func (db *DBStore) getElementProof(leafIndex, numLeaves uint64) (proof []types.H
 	return
 }
 
-func (db *DBStore) getBigFileElement(id types.BigFileOutputID, numLeaves uint64) (sce types.BigFileElement, ok bool) {
-	ok = db.bucket(bBigFileElements).get(id[:], &sce)
+func (db *DBStore) getBigFileElement(id types.BigFileOutputID, numLeaves uint64) (bige types.BigFileElement, ok bool) {
+	ok = db.bucket(bBigFileElements).get(id[:], &bige)
 	if ok {
-		sce.StateElement.MerkleProof = db.getElementProof(sce.StateElement.LeafIndex, numLeaves)
+		bige.StateElement.MerkleProof = db.getElementProof(bige.StateElement.LeafIndex, numLeaves)
 	}
 	return
 }
 
-func (db *DBStore) putBigFileElement(sce types.BigFileElement) {
-	sce.StateElement.MerkleProof = nil
-	db.bucket(bBigFileElements).put(sce.ID[:], sce.Share())
+func (db *DBStore) putBigFileElement(bige types.BigFileElement) {
+	bige.StateElement.MerkleProof = nil
+	db.bucket(bBigFileElements).put(bige.ID[:], bige.Share())
 }
 
 func (db *DBStore) deleteBigFileElement(id types.BigFileOutputID) {
@@ -642,13 +642,13 @@ func (db *DBStore) applyElements(cau consensus.ApplyUpdate) {
 		db.bucket(bTree).putRaw(db.treeKey(row, col), h[:])
 	})
 
-	for _, sced := range cau.BigFileElementDiffs() {
-		if sced.Created && sced.Spent {
+	for _, biged := range cau.BigFileElementDiffs() {
+		if biged.Created && biged.Spent {
 			continue // ephemeral
-		} else if sced.Spent {
-			db.deleteBigFileElement(sced.BigFileElement.ID)
+		} else if biged.Spent {
+			db.deleteBigFileElement(biged.BigFileElement.ID)
 		} else {
-			db.putBigFileElement(sced.BigFileElement.Share())
+			db.putBigFileElement(biged.BigFileElement.Share())
 		}
 	}
 	for _, sfed := range cau.SiafundElementDiffs() {
@@ -718,15 +718,15 @@ func (db *DBStore) revertElements(cru consensus.RevertUpdate) {
 			db.deleteSiafundElement(sfed.SiafundElement.ID)
 		}
 	}
-	for _, sced := range cru.BigFileElementDiffs() {
-		if sced.Created && sced.Spent {
+	for _, biged := range cru.BigFileElementDiffs() {
+		if biged.Created && biged.Spent {
 			continue // ephemeral
-		} else if sced.Spent {
+		} else if biged.Spent {
 			// output no longer spent; restore it
-			db.putBigFileElement(sced.BigFileElement.Share())
+			db.putBigFileElement(biged.BigFileElement.Share())
 		} else {
 			// output no longer exists; delete it
-			db.deleteBigFileElement(sced.BigFileElement.ID)
+			db.deleteBigFileElement(biged.BigFileElement.ID)
 		}
 	}
 
@@ -760,9 +760,9 @@ func (db *DBStore) SupplementTipTransaction(txn types.Transaction) (ts consensus
 	cs, _ := db.State(index.ID)
 	numLeaves := cs.Elements.NumLeaves
 
-	for _, sci := range txn.BigFileInputs {
-		if sce, ok := db.getBigFileElement(sci.ParentID, numLeaves); ok {
-			ts.BigFileInputs = append(ts.BigFileInputs, sce.Move())
+	for _, bigi := range txn.BigFileInputs {
+		if bige, ok := db.getBigFileElement(bigi.ParentID, numLeaves); ok {
+			ts.BigFileInputs = append(ts.BigFileInputs, bige.Move())
 		}
 	}
 	for _, sfi := range txn.SiafundInputs {

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -711,9 +711,9 @@ func (m *Manager) revertPoolUpdate(cru consensus.RevertUpdate, cs consensus.Stat
 			return
 		} else if uncreated == nil {
 			uncreated = make(map[types.Hash256]bool)
-			for _, sced := range cru.BigFileElementDiffs() {
-				if sced.Created {
-					uncreated[types.Hash256(sced.BigFileElement.ID)] = true
+			for _, biged := range cru.BigFileElementDiffs() {
+				if biged.Created {
+					uncreated[types.Hash256(biged.BigFileElement.ID)] = true
 				}
 			}
 			for _, sfed := range cru.SiafundElementDiffs() {
@@ -769,9 +769,9 @@ func (m *Manager) applyPoolUpdate(cau consensus.ApplyUpdate, cs consensus.State)
 		} else if newElements == nil {
 			newElements = make(map[types.Hash256]types.StateElement)
 
-			for _, sced := range cau.BigFileElementDiffs() {
-				if sced.Created {
-					newElements[types.Hash256(sced.BigFileElement.ID)] = sced.BigFileElement.StateElement.Share()
+			for _, biged := range cau.BigFileElementDiffs() {
+				if biged.Created {
+					newElements[types.Hash256(biged.BigFileElement.ID)] = biged.BigFileElement.StateElement.Share()
 				}
 			}
 			for _, sfed := range cau.SiafundElementDiffs() {
@@ -950,8 +950,8 @@ func (m *Manager) UnconfirmedParents(txn types.Transaction) []types.Transaction 
 		}
 	}
 	addParents := func(txn types.Transaction) {
-		for _, sci := range txn.BigFileInputs {
-			check(types.Hash256(sci.ParentID))
+		for _, bigi := range txn.BigFileInputs {
+			check(types.Hash256(bigi.ParentID))
 		}
 		for _, sfi := range txn.SiafundInputs {
 			check(types.Hash256(sfi.ParentID))
@@ -1012,8 +1012,8 @@ func (m *Manager) V2TransactionSet(basis types.ChainIndex, txn types.V2Transacti
 		}
 	}
 	addParents := func(txn types.V2Transaction) {
-		for _, sci := range txn.BigFileInputs {
-			check(types.Hash256(sci.Parent.ID))
+		for _, bigi := range txn.BigFileInputs {
+			check(types.Hash256(bigi.Parent.ID))
 		}
 		for _, sfi := range txn.SiafundInputs {
 			check(types.Hash256(sfi.Parent.ID))
@@ -1135,9 +1135,9 @@ func (m *Manager) updateV2TransactionProofs(txns []types.V2Transaction, from, to
 			confirmedTxns[txn.ID()] = true
 		}
 		confirmedStateElements := make(map[types.Hash256]types.StateElement)
-		for _, sced := range cau.BigFileElementDiffs() {
-			if sced.Created {
-				confirmedStateElements[types.Hash256(sced.BigFileElement.ID)] = sced.BigFileElement.StateElement.Share()
+		for _, biged := range cau.BigFileElementDiffs() {
+			if biged.Created {
+				confirmedStateElements[types.Hash256(biged.BigFileElement.ID)] = biged.BigFileElement.StateElement.Share()
 			}
 		}
 		for _, sfed := range cau.SiafundElementDiffs() {

--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -111,10 +111,10 @@ func TestTxPool(t *testing.T) {
 	giftPrivateKey := types.GeneratePrivateKey()
 	giftPublicKey := giftPrivateKey.PublicKey()
 	giftAddress := types.StandardUnlockHash(giftPublicKey)
-	giftAmountSC := types.BigFiles(100)
+	giftAmountBIG := types.BigFiles(100)
 	giftTxn := types.Transaction{
 		BigFileOutputs: []types.BigFileOutput{
-			{Address: giftAddress, Value: giftAmountSC},
+			{Address: giftAddress, Value: giftAmountBIG},
 		},
 	}
 	genesisBlock.Transactions = []types.Transaction{giftTxn}
@@ -136,10 +136,10 @@ func TestTxPool(t *testing.T) {
 	})
 
 	signTxn := func(txn *types.Transaction) {
-		for _, sci := range txn.BigFileInputs {
-			sig := giftPrivateKey.SignHash(cm.TipState().WholeSigHash(*txn, types.Hash256(sci.ParentID), 0, 0, nil))
+		for _, bigi := range txn.BigFileInputs {
+			sig := giftPrivateKey.SignHash(cm.TipState().WholeSigHash(*txn, types.Hash256(bigi.ParentID), 0, 0, nil))
 			txn.Signatures = append(txn.Signatures, types.TransactionSignature{
-				ParentID:       types.Hash256(sci.ParentID),
+				ParentID:       types.Hash256(bigi.ParentID),
 				CoveredFields:  types.CoveredFields{WholeTransaction: true},
 				PublicKeyIndex: 0,
 				Signature:      sig[:],
@@ -155,7 +155,7 @@ func TestTxPool(t *testing.T) {
 		}},
 		BigFileOutputs: []types.BigFileOutput{{
 			Address: giftAddress,
-			Value:   giftAmountSC,
+			Value:   giftAmountBIG,
 		}},
 	}
 	signTxn(&parentTxn)
@@ -173,7 +173,7 @@ func TestTxPool(t *testing.T) {
 			ParentID:         parentTxn.BigFileOutputID(0),
 			UnlockConditions: types.StandardUnlockConditions(giftPublicKey),
 		}},
-		MinerFees: []types.Currency{giftAmountSC},
+		MinerFees: []types.Currency{giftAmountBIG},
 	}
 	signTxn(&childTxn)
 	// submitted alone, it should be rejected
@@ -204,7 +204,7 @@ func TestTxPool(t *testing.T) {
 		ParentID:  cm.TipState().Index.ID,
 		Timestamp: types.CurrentTimestamp(),
 		MinerPayouts: []types.BigFileOutput{{
-			Value:   cm.TipState().BlockReward().Add(giftAmountSC),
+			Value:   cm.TipState().BlockReward().Add(giftAmountBIG),
 			Address: types.Address(frand.Entropy256()),
 		}},
 		Transactions: cm.PoolTransactions(),
@@ -231,10 +231,10 @@ func TestUpdateV2TransactionSet(t *testing.T) {
 	giftPrivateKey := types.GeneratePrivateKey()
 	giftPublicKey := giftPrivateKey.PublicKey()
 	giftAddress := types.StandardAddress(giftPublicKey)
-	giftAmountSC := types.BigFiles(100)
+	giftAmountBIG := types.BigFiles(100)
 	giftTxn := types.Transaction{
 		BigFileOutputs: []types.BigFileOutput{
-			{Address: giftAddress, Value: giftAmountSC},
+			{Address: giftAddress, Value: giftAmountBIG},
 		},
 	}
 	genesisBlock.Transactions = []types.Transaction{giftTxn}
@@ -250,7 +250,7 @@ func TestUpdateV2TransactionSet(t *testing.T) {
 				Signatures: []types.Signature{},
 			},
 		}},
-		MinerFee: giftAmountSC,
+		MinerFee: giftAmountBIG,
 	}
 	txn.BigFileInputs[0].SatisfiedPolicy.Signatures = []types.Signature{giftPrivateKey.SignHash(cs.InputSigHash(txn))}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.thebigfile.com/coreutils // v0.0.8
+module go.thebigfile.com/coreutils // v0.0.9
 
 go 1.23.1
 
@@ -8,7 +8,7 @@ require (
 	github.com/quic-go/quic-go v0.51.0
 	github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66
 	go.etcd.io/bbolt v1.4.0
-	go.thebigfile.com/core v1.0.2
+	go.thebigfile.com/core v1.0.3
 	go.thebigfile.com/mux v0.0.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
-go.thebigfile.com/core v1.0.2 h1:stOTdX1yld7frTyoYAbRFsCBOcfbLHmyCJ3JuxikJeQ=
-go.thebigfile.com/core v1.0.2/go.mod h1:4lg9eAT9pYhUmYpTq6S+e61wPxYjO57dZaBEEApASKA=
+go.thebigfile.com/core v1.0.3 h1:zeYIKzJ53wYD0SQNKl0l0Q1hKyeu4Ruy5Mi13y1I5I0=
+go.thebigfile.com/core v1.0.3/go.mod h1:RDay3RHIUlylEW4FV1k4pbcCfcToFjdP47hB8NjDR0Q=
 go.thebigfile.com/mux v0.0.1 h1:BfsWkNBv648G/2ZGQ9gQefrdMvNydY7kIK+Jtdm0o1M=
 go.thebigfile.com/mux v0.0.1/go.mod h1:+DmAbPgE/AVqt1tAN1WfOiO5xl2m/B2MvyMku1qtVVQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/miner_test.go
+++ b/miner_test.go
@@ -43,10 +43,10 @@ func TestMiner(t *testing.T) {
 	}
 
 	// sign the inputs
-	for _, sci := range txn.BigFileInputs {
-		sig := sk.SignHash(cm.TipState().WholeSigHash(txn, types.Hash256(sci.ParentID), 0, 0, nil))
+	for _, bigi := range txn.BigFileInputs {
+		sig := sk.SignHash(cm.TipState().WholeSigHash(txn, types.Hash256(bigi.ParentID), 0, 0, nil))
 		txn.Signatures = append(txn.Signatures, types.TransactionSignature{
-			ParentID:       types.Hash256(sci.ParentID),
+			ParentID:       types.Hash256(bigi.ParentID),
 			CoveredFields:  types.CoveredFields{WholeTransaction: true},
 			PublicKeyIndex: 0,
 			Signature:      sig[:],
@@ -111,14 +111,14 @@ func TestV2MineBlocks(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, cau := range applied {
-		for _, sced := range cau.BigFileElementDiffs() {
-			sce := sced.BigFileElement
-			if sce.BigFileOutput.Address == types.AnyoneCanSpend().Address() {
-				if sced.Created {
-					elements[sce.ID] = sce
+		for _, biged := range cau.BigFileElementDiffs() {
+			bige := biged.BigFileElement
+			if bige.BigFileOutput.Address == types.AnyoneCanSpend().Address() {
+				if biged.Created {
+					elements[bige.ID] = bige
 				}
-				if sced.Spent {
-					delete(elements, sce.ID)
+				if biged.Spent {
+					delete(elements, bige.ID)
 				}
 			}
 		}

--- a/rhp/v4/server.go
+++ b/rhp/v4/server.go
@@ -624,11 +624,11 @@ func (s *Server) handleRPCFormContract(stream net.Conn) error {
 
 	// calculate the renter inputs
 	var renterInputs types.Currency
-	for _, sce := range req.RenterInputs {
+	for _, bige := range req.RenterInputs {
 		formationTxn.BigFileInputs = append(formationTxn.BigFileInputs, types.V2BigFileInput{
-			Parent: sce.Move(),
+			Parent: bige.Move(),
 		})
-		renterInputs = renterInputs.Add(sce.BigFileOutput.Value)
+		renterInputs = renterInputs.Add(bige.BigFileOutput.Value)
 	}
 
 	// calculate the required funding
@@ -728,12 +728,11 @@ func (s *Server) handleRPCFormContract(stream net.Conn) error {
 	}, usage)
 	if err != nil {
 		return fmt.Errorf("failed to add contract: %w", err)
-		} else if err := s.syncer.BroadcastV2TransactionSet(basis, formationSet); err != nil {
-			return fmt.Errorf("failed to broadcast transaction set: %w", err)
+	} else if err := s.syncer.BroadcastV2TransactionSet(basis, formationSet); err != nil {
+		return fmt.Errorf("failed to broadcast transaction set: %w", err)
 	}
-	
-	broadcast = true // set broadcast so the UTXOs will not be released if the renter happens to disconnect before receiving the last response
 
+	broadcast = true // set broadcast so the UTXOs will not be released if the renter happens to disconnect before receiving the last response
 
 	// send the finalized transaction set to the renter
 	return rhp4.WriteResponse(stream, &rhp4.RPCFormContractThirdResponse{
@@ -773,7 +772,6 @@ func (s *Server) handleRPCRefreshContract(stream net.Conn) error {
 	if err := req.Validate(s.hostKey.PublicKey(), cs.Index, state.Revision, settings.MaxCollateral); err != nil {
 		return rhp4.NewRPCError(rhp4.ErrorCodeBadRequest, err.Error())
 	}
-
 
 	renewal, usage := rhp4.RefreshContract(existing, prices, req.Refresh)
 	renterCost, hostCost := rhp4.RefreshCost(cs, prices, renewal, req.MinerFee)
@@ -907,12 +905,11 @@ func (s *Server) handleRPCRefreshContract(stream net.Conn) error {
 	}, usage)
 	if err != nil {
 		return fmt.Errorf("failed to add contract: %w", err)
-		} else if err := s.syncer.BroadcastV2TransactionSet(basis, renewalSet); err != nil {
-			return fmt.Errorf("failed to broadcast transaction set: %w", err)
+	} else if err := s.syncer.BroadcastV2TransactionSet(basis, renewalSet); err != nil {
+		return fmt.Errorf("failed to broadcast transaction set: %w", err)
 	}
 
 	broadcast = true // set broadcast so the UTXOs will not be released if the renter happens to disconnect before receiving the last response
-
 
 	// send the finalized transaction set to the renter
 	return rhp4.WriteResponse(stream, &rhp4.RPCRefreshContractThirdResponse{
@@ -1087,12 +1084,11 @@ func (s *Server) handleRPCRenewContract(stream net.Conn) error {
 	}, usage)
 	if err != nil {
 		return fmt.Errorf("failed to add contract: %w", err)
-		} else if err := s.syncer.BroadcastV2TransactionSet(basis, renewalSet); err != nil {
-			return fmt.Errorf("failed to broadcast transaction set: %w", err)
+	} else if err := s.syncer.BroadcastV2TransactionSet(basis, renewalSet); err != nil {
+		return fmt.Errorf("failed to broadcast transaction set: %w", err)
 	}
 
 	broadcast = true // set broadcast so the UTXOs will not be released if the renter happens to disconnect before receiving the last response
-
 
 	// send the finalized transaction set to the renter
 	return rhp4.WriteResponse(stream, &rhp4.RPCRenewContractThirdResponse{

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -12,7 +12,7 @@ type (
 	// A ChainUpdate is an interface for iterating over the elements in a chain
 	// update.
 	ChainUpdate interface {
-		ForEachBigFileElement(func(sce types.BigFileElement, spent bool))
+		ForEachBigFileElement(func(bige types.BigFileElement, spent bool))
 		ForEachSiafundElement(func(sfe types.SiafundElement, spent bool))
 		ForEachFileContractElement(func(fce types.FileContractElement, rev *types.FileContractElement, resolved, valid bool))
 		ForEachV2FileContractElement(func(fce types.V2FileContractElement, rev *types.V2FileContractElement, res types.V2FileContractResolutionType))
@@ -91,9 +91,9 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 	siacoinElements := make(map[types.BigFileOutputID]types.BigFileElement)
 
 	// cache the value of bigfile elements to use when calculating v1 outflow
-	for _, sced := range cau.BigFileElementDiffs() {
-		sced.BigFileElement.StateElement.MerkleProof = nil // clear the proof to save space
-		siacoinElements[sced.BigFileElement.ID] = sced.BigFileElement.Move()
+	for _, biged := range cau.BigFileElementDiffs() {
+		biged.BigFileElement.StateElement.MerkleProof = nil // clear the proof to save space
+		siacoinElements[biged.BigFileElement.ID] = biged.BigFileElement.Move()
 	}
 
 	addEvent := func(id types.Hash256, eventType string, data EventData, maturityHeight uint64) {
@@ -121,14 +121,14 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 		for _, si := range txn.SiafundInputs {
 			if si.UnlockConditions.UnlockHash() == walletAddress {
 				outputID := si.ParentID.ClaimOutputID()
-				sce, ok := siacoinElements[outputID]
+				bige, ok := siacoinElements[outputID]
 				if !ok {
 					panic("missing claim bigfile element")
 				}
 
 				addEvent(types.Hash256(outputID), EventTypeSiafundClaim, EventPayout{
-					BigFileElement: sce.Copy(),
-				}, sce.MaturityHeight)
+					BigFileElement: bige.Copy(),
+				}, bige.MaturityHeight)
 			}
 		}
 
@@ -155,14 +155,14 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 		for _, si := range txn.SiafundInputs {
 			if si.Parent.SiafundOutput.Address == walletAddress {
 				outputID := types.SiafundOutputID(si.Parent.ID).V2ClaimOutputID()
-				sce, ok := siacoinElements[outputID]
+				bige, ok := siacoinElements[outputID]
 				if !ok {
 					panic("missing claim bigfile element")
 				}
 
 				addEvent(types.Hash256(outputID), EventTypeSiafundClaim, EventPayout{
-					BigFileElement: sce.Copy(),
-				}, sce.MaturityHeight)
+					BigFileElement: bige.Copy(),
+				}, bige.MaturityHeight)
 			}
 		}
 
@@ -184,16 +184,16 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 				}
 
 				outputID := fce.ID.ValidOutputID(i)
-				sce, ok := siacoinElements[outputID]
+				bige, ok := siacoinElements[outputID]
 				if !ok {
 					panic("missing bigfile element")
 				}
 
 				addEvent(types.Hash256(outputID), EventTypeV1ContractResolution, EventV1ContractResolution{
 					Parent:         fce.Copy(),
-					BigFileElement: sce.Copy(),
+					BigFileElement: bige.Copy(),
 					Missed:         false,
-				}, sce.MaturityHeight)
+				}, bige.MaturityHeight)
 			}
 		} else {
 			for i, so := range fce.FileContract.MissedProofOutputs {
@@ -202,16 +202,16 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 				}
 
 				outputID := fce.ID.MissedOutputID(i)
-				sce, ok := siacoinElements[outputID]
+				bige, ok := siacoinElements[outputID]
 				if !ok {
 					panic("missing bigfile element")
 				}
 
 				addEvent(types.Hash256(outputID), EventTypeV1ContractResolution, EventV1ContractResolution{
 					Parent:         fce.Copy(),
-					BigFileElement: sce.Copy(),
+					BigFileElement: bige.Copy(),
 					Missed:         true,
-				}, sce.MaturityHeight)
+				}, bige.MaturityHeight)
 			}
 		}
 	}
@@ -226,7 +226,7 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 		_, missed := fced.Resolution.(*types.V2FileContractExpiration)
 		if fce.V2FileContract.HostOutput.Address == walletAddress {
 			outputID := fce.ID.V2HostOutputID()
-			sce, ok := siacoinElements[outputID]
+			bige, ok := siacoinElements[outputID]
 			if !ok {
 				panic("missing bigfile element")
 			}
@@ -236,14 +236,14 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 					Parent:     fce.Copy(),
 					Resolution: fced.Resolution,
 				},
-				BigFileElement: sce.Copy(),
+				BigFileElement: bige.Copy(),
 				Missed:         missed,
-			}, sce.MaturityHeight)
+			}, bige.MaturityHeight)
 		}
 
 		if fce.V2FileContract.RenterOutput.Address == walletAddress {
 			outputID := fce.ID.V2RenterOutputID()
-			sce, ok := siacoinElements[outputID]
+			bige, ok := siacoinElements[outputID]
 			if !ok {
 				panic("missing bigfile element")
 			}
@@ -253,9 +253,9 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 					Parent:     fce.Copy(),
 					Resolution: fced.Resolution,
 				},
-				BigFileElement: sce.Copy(),
+				BigFileElement: bige.Copy(),
 				Missed:         missed,
-			}, sce.MaturityHeight)
+			}, bige.MaturityHeight)
 		}
 	}
 
@@ -266,20 +266,20 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 		}
 
 		outputID := blockID.MinerOutputID(i)
-		sce, ok := siacoinElements[outputID]
+		bige, ok := siacoinElements[outputID]
 		if !ok {
 			panic("missing bigfile element")
 		}
 		addEvent(types.Hash256(outputID), EventTypeMinerPayout, EventPayout{
-			BigFileElement: sce.Copy(),
-		}, sce.MaturityHeight)
+			BigFileElement: bige.Copy(),
+		}, bige.MaturityHeight)
 	}
 
 	outputID := blockID.FoundationOutputID()
-	if sce, ok := siacoinElements[outputID]; ok && sce.BigFileOutput.Address == walletAddress {
+	if bige, ok := siacoinElements[outputID]; ok && bige.BigFileOutput.Address == walletAddress {
 		addEvent(types.Hash256(outputID), EventTypeFoundationSubsidy, EventPayout{
-			BigFileElement: sce.Copy(),
-		}, sce.MaturityHeight)
+			BigFileElement: bige.Copy(),
+		}, bige.MaturityHeight)
 	}
 	return
 }
@@ -292,16 +292,16 @@ func (sw *SingleAddressWallet) applyChainUpdate(tx UpdateTx, address types.Addre
 	}
 
 	var createdUTXOs, spentUTXOs []types.BigFileElement
-	for _, sced := range cau.BigFileElementDiffs() {
+	for _, biged := range cau.BigFileElementDiffs() {
 		switch {
-		case sced.Created && sced.Spent:
+		case biged.Created && biged.Spent:
 			continue // ignore ephemeral elements
-		case sced.BigFileElement.BigFileOutput.Address != address:
+		case biged.BigFileElement.BigFileOutput.Address != address:
 			continue // ignore elements that are not related to the wallet
-		case sced.Created:
-			createdUTXOs = append(createdUTXOs, sced.BigFileElement.Share())
-		case sced.Spent:
-			spentUTXOs = append(spentUTXOs, sced.BigFileElement.Share())
+		case biged.Created:
+			createdUTXOs = append(createdUTXOs, biged.BigFileElement.Share())
+		case biged.Spent:
+			spentUTXOs = append(spentUTXOs, biged.BigFileElement.Share())
 		default:
 			panic("unexpected bigfile element") // developer error
 		}
@@ -319,16 +319,16 @@ func (sw *SingleAddressWallet) applyChainUpdate(tx UpdateTx, address types.Addre
 // revertChainUpdate atomically reverts a chain update from a wallet
 func (sw *SingleAddressWallet) revertChainUpdate(tx UpdateTx, revertedIndex types.ChainIndex, address types.Address, cru chain.RevertUpdate) error {
 	var removedUTXOs, unspentUTXOs []types.BigFileElement
-	for _, sced := range cru.BigFileElementDiffs() {
+	for _, biged := range cru.BigFileElementDiffs() {
 		switch {
-		case sced.Created && sced.Spent:
+		case biged.Created && biged.Spent:
 			continue // ignore ephemeral elements
-		case sced.BigFileElement.BigFileOutput.Address != address:
+		case biged.BigFileElement.BigFileOutput.Address != address:
 			continue // ignore elements that are not related to the wallet
-		case sced.Spent:
-			unspentUTXOs = append(unspentUTXOs, sced.BigFileElement.Share())
-		case sced.Created:
-			removedUTXOs = append(removedUTXOs, sced.BigFileElement.Share())
+		case biged.Spent:
+			unspentUTXOs = append(unspentUTXOs, biged.BigFileElement.Share())
+		case biged.Created:
+			removedUTXOs = append(removedUTXOs, biged.BigFileElement.Share())
 		default:
 			panic("unexpected bigfile element") // developer error
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -119,15 +119,15 @@ func (sw *SingleAddressWallet) Balance() (balance Balance, err error) {
 	tpoolSpent := make(map[types.BigFileOutputID]bool)
 	tpoolUtxos := make(map[types.BigFileOutputID]types.BigFileElement)
 	for _, txn := range sw.cm.PoolTransactions() {
-		for _, sci := range txn.BigFileInputs {
-			if sci.UnlockConditions.UnlockHash() != sw.addr {
+		for _, bigi := range txn.BigFileInputs {
+			if bigi.UnlockConditions.UnlockHash() != sw.addr {
 				continue
 			}
-			tpoolSpent[sci.ParentID] = true
-			delete(tpoolUtxos, sci.ParentID)
+			tpoolSpent[bigi.ParentID] = true
+			delete(tpoolUtxos, bigi.ParentID)
 		}
-		for i, sco := range txn.BigFileOutputs {
-			if sco.Address != sw.addr {
+		for i, bigo := range txn.BigFileOutputs {
+			if bigo.Address != sw.addr {
 				continue
 			}
 
@@ -135,7 +135,7 @@ func (sw *SingleAddressWallet) Balance() (balance Balance, err error) {
 			tpoolUtxos[outputID] = types.BigFileElement{
 				ID:            types.BigFileOutputID(outputID),
 				StateElement:  types.StateElement{LeafIndex: types.UnassignedLeafIndex},
-				BigFileOutput: sco,
+				BigFileOutput: bigo,
 			}
 		}
 	}
@@ -148,31 +148,31 @@ func (sw *SingleAddressWallet) Balance() (balance Balance, err error) {
 			tpoolSpent[si.Parent.ID] = true
 			delete(tpoolUtxos, si.Parent.ID)
 		}
-		for i, sco := range txn.BigFileOutputs {
-			if sco.Address != sw.addr {
+		for i, bigo := range txn.BigFileOutputs {
+			if bigo.Address != sw.addr {
 				continue
 			}
-			sce := txn.EphemeralBigFileOutput(i)
-			tpoolUtxos[sce.ID] = sce.Move()
+			bige := txn.EphemeralBigFileOutput(i)
+			tpoolUtxos[bige.ID] = bige.Move()
 		}
 	}
 
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 	bh := sw.cm.TipState().Index.Height
-	for _, sco := range outputs {
-		if sco.MaturityHeight > bh {
-			balance.Immature = balance.Immature.Add(sco.BigFileOutput.Value)
+	for _, bigo := range outputs {
+		if bigo.MaturityHeight > bh {
+			balance.Immature = balance.Immature.Add(bigo.BigFileOutput.Value)
 		} else {
-			balance.Confirmed = balance.Confirmed.Add(sco.BigFileOutput.Value)
-			if !sw.isLocked(sco.ID) && !tpoolSpent[sco.ID] {
-				balance.Spendable = balance.Spendable.Add(sco.BigFileOutput.Value)
+			balance.Confirmed = balance.Confirmed.Add(bigo.BigFileOutput.Value)
+			if !sw.isLocked(bigo.ID) && !tpoolSpent[bigo.ID] {
+				balance.Spendable = balance.Spendable.Add(bigo.BigFileOutput.Value)
 			}
 		}
 	}
 
-	for _, sco := range tpoolUtxos {
-		balance.Unconfirmed = balance.Unconfirmed.Add(sco.BigFileOutput.Value)
+	for _, bigo := range tpoolUtxos {
+		balance.Unconfirmed = balance.Unconfirmed.Add(bigo.BigFileOutput.Value)
 	}
 	return
 }
@@ -201,8 +201,8 @@ func (sw *SingleAddressWallet) SpendableOutputs() ([]types.BigFileElement, error
 	// fetch outputs currently in the pool
 	inPool := make(map[types.BigFileOutputID]bool)
 	for _, txn := range sw.cm.PoolTransactions() {
-		for _, sci := range txn.BigFileInputs {
-			inPool[sci.ParentID] = true
+		for _, bigi := range txn.BigFileInputs {
+			inPool[bigi.ParentID] = true
 		}
 	}
 
@@ -215,11 +215,11 @@ func (sw *SingleAddressWallet) SpendableOutputs() ([]types.BigFileElement, error
 
 	// filter outputs that are either locked, in the pool or have not yet matured
 	unspent := utxos[:0]
-	for _, sce := range utxos {
-		if sw.isLocked(sce.ID) || inPool[sce.ID] || bh < sce.MaturityHeight {
+	for _, bige := range utxos {
+		if sw.isLocked(bige.ID) || inPool[bige.ID] || bh < bige.MaturityHeight {
 			continue
 		}
-		unspent = append(unspent, sce.Copy())
+		unspent = append(unspent, bige.Copy())
 	}
 	return unspent, nil
 }
@@ -232,26 +232,26 @@ func (sw *SingleAddressWallet) selectUTXOs(amount types.Currency, inputs int, us
 	tpoolSpent := make(map[types.BigFileOutputID]bool)
 	tpoolUtxos := make(map[types.BigFileOutputID]types.BigFileElement)
 	for _, txn := range sw.cm.PoolTransactions() {
-		for _, sci := range txn.BigFileInputs {
-			tpoolSpent[sci.ParentID] = true
-			delete(tpoolUtxos, sci.ParentID)
+		for _, bigi := range txn.BigFileInputs {
+			tpoolSpent[bigi.ParentID] = true
+			delete(tpoolUtxos, bigi.ParentID)
 		}
-		for i, sco := range txn.BigFileOutputs {
+		for i, bigo := range txn.BigFileOutputs {
 			tpoolUtxos[txn.BigFileOutputID(i)] = types.BigFileElement{
 				ID:            txn.BigFileOutputID(i),
 				StateElement:  types.StateElement{LeafIndex: types.UnassignedLeafIndex},
-				BigFileOutput: sco,
+				BigFileOutput: bigo,
 			}
 		}
 	}
 	for _, txn := range sw.cm.V2PoolTransactions() {
-		for _, sci := range txn.BigFileInputs {
-			tpoolSpent[sci.Parent.ID] = true
-			delete(tpoolUtxos, sci.Parent.ID)
+		for _, bigi := range txn.BigFileInputs {
+			tpoolSpent[bigi.Parent.ID] = true
+			delete(tpoolUtxos, bigi.Parent.ID)
 		}
 		for i := range txn.BigFileOutputs {
-			sce := txn.EphemeralBigFileOutput(i)
-			tpoolUtxos[sce.ID] = sce.Move()
+			bige := txn.EphemeralBigFileOutput(i)
+			tpoolUtxos[bige.ID] = bige.Move()
 		}
 	}
 
@@ -260,15 +260,15 @@ func (sw *SingleAddressWallet) selectUTXOs(amount types.Currency, inputs int, us
 	utxos := make([]types.BigFileElement, 0, len(elements))
 	var usedSum types.Currency
 	var immatureSum types.Currency
-	for _, sce := range elements {
-		if used := sw.isLocked(sce.ID) || tpoolSpent[sce.ID]; used {
-			usedSum = usedSum.Add(sce.BigFileOutput.Value)
+	for _, bige := range elements {
+		if used := sw.isLocked(bige.ID) || tpoolSpent[bige.ID]; used {
+			usedSum = usedSum.Add(bige.BigFileOutput.Value)
 			continue
-		} else if immature := cs.Index.Height < sce.MaturityHeight; immature {
-			immatureSum = immatureSum.Add(sce.BigFileOutput.Value)
+		} else if immature := cs.Index.Height < bige.MaturityHeight; immature {
+			immatureSum = immatureSum.Add(bige.BigFileOutput.Value)
 			continue
 		}
-		utxos = append(utxos, sce.Share())
+		utxos = append(utxos, bige.Share())
 	}
 
 	// sort by value, descending
@@ -279,12 +279,12 @@ func (sw *SingleAddressWallet) selectUTXOs(amount types.Currency, inputs int, us
 	var unconfirmedUTXOs []types.BigFileElement
 	var unconfirmedSum types.Currency
 	if useUnconfirmed {
-		for _, sce := range tpoolUtxos {
-			if sce.BigFileOutput.Address != sw.addr || sw.isLocked(sce.ID) {
+		for _, bige := range tpoolUtxos {
+			if bige.BigFileOutput.Address != sw.addr || sw.isLocked(bige.ID) {
 				continue
 			}
-			unconfirmedUTXOs = append(unconfirmedUTXOs, sce.Share())
-			unconfirmedSum = unconfirmedSum.Add(sce.BigFileOutput.Value)
+			unconfirmedUTXOs = append(unconfirmedUTXOs, bige.Share())
+			unconfirmedSum = unconfirmedSum.Add(bige.BigFileOutput.Value)
 		}
 	}
 
@@ -296,20 +296,20 @@ func (sw *SingleAddressWallet) selectUTXOs(amount types.Currency, inputs int, us
 	// fund the transaction using the largest utxos first
 	var selected []types.BigFileElement
 	var inputSum types.Currency
-	for i, sce := range utxos {
+	for i, bige := range utxos {
 		if inputSum.Cmp(amount) >= 0 {
 			utxos = utxos[i:]
 			break
 		}
-		selected = append(selected, sce.Share())
-		inputSum = inputSum.Add(sce.BigFileOutput.Value)
+		selected = append(selected, bige.Share())
+		inputSum = inputSum.Add(bige.BigFileOutput.Value)
 	}
 
 	if inputSum.Cmp(amount) < 0 && useUnconfirmed {
 		// try adding unconfirmed utxos.
-		for _, sce := range unconfirmedUTXOs {
-			selected = append(selected, sce.Share())
-			inputSum = inputSum.Add(sce.BigFileOutput.Value)
+		for _, bige := range unconfirmedUTXOs {
+			selected = append(selected, bige.Share())
+			inputSum = inputSum.Add(bige.BigFileOutput.Value)
 			if inputSum.Cmp(amount) >= 0 {
 				break
 			}
@@ -336,9 +336,9 @@ func (sw *SingleAddressWallet) selectUTXOs(amount types.Currency, inputs int, us
 				break
 			}
 
-			sce := &defraggable[i]
-			selected = append(selected, sce.Share())
-			inputSum = inputSum.Add(sce.BigFileOutput.Value)
+			bige := &defraggable[i]
+			selected = append(selected, bige.Share())
+			inputSum = inputSum.Add(bige.BigFileOutput.Value)
 			txnInputs++
 		}
 	}
@@ -376,13 +376,13 @@ func (sw *SingleAddressWallet) FundTransaction(txn *types.Transaction, amount ty
 	}
 
 	toSign := make([]types.Hash256, len(selected))
-	for i, sce := range selected {
+	for i, bige := range selected {
 		txn.BigFileInputs = append(txn.BigFileInputs, types.BigFileInput{
-			ParentID:         sce.ID,
+			ParentID:         bige.ID,
 			UnlockConditions: types.StandardUnlockConditions(sw.priv.PublicKey()),
 		})
-		toSign[i] = types.Hash256(sce.ID)
-		sw.locked[sce.ID] = time.Now().Add(sw.cfg.ReservationDuration)
+		toSign[i] = types.Hash256(bige.ID)
+		sw.locked[bige.ID] = time.Now().Add(sw.cfg.ReservationDuration)
 	}
 
 	return toSign, nil
@@ -446,12 +446,12 @@ func (sw *SingleAddressWallet) FundV2Transaction(txn *types.V2Transaction, amoun
 	}
 
 	toSign := make([]int, 0, len(selected))
-	for _, sce := range selected {
+	for _, bige := range selected {
 		toSign = append(toSign, len(txn.BigFileInputs))
 		txn.BigFileInputs = append(txn.BigFileInputs, types.V2BigFileInput{
-			Parent: sce.Copy(),
+			Parent: bige.Copy(),
 		})
-		sw.locked[sce.ID] = time.Now().Add(sw.cfg.ReservationDuration)
+		sw.locked[bige.ID] = time.Now().Add(sw.cfg.ReservationDuration)
 	}
 
 	return sw.tip, toSign, nil
@@ -535,14 +535,14 @@ func (sw *SingleAddressWallet) UnconfirmedEvents() (annotated []Event, err error
 		}
 
 		var outflow types.Currency
-		for _, sci := range txn.BigFileInputs {
-			sce, ok := utxos[sci.ParentID]
+		for _, bigi := range txn.BigFileInputs {
+			bige, ok := utxos[bigi.ParentID]
 			if !ok {
 				// ignore inputs that don't belong to the wallet
 				continue
 			}
-			outflow = outflow.Add(sce.BigFileOutput.Value)
-			event.SpentBigFileElements = append(event.SpentBigFileElements, sce.Share())
+			outflow = outflow.Add(bige.BigFileOutput.Value)
+			event.SpentBigFileElements = append(event.SpentBigFileElements, bige.Share())
 		}
 
 		var inflow types.Currency
@@ -566,18 +566,18 @@ func (sw *SingleAddressWallet) UnconfirmedEvents() (annotated []Event, err error
 
 	for _, txn := range sw.cm.V2PoolTransactions() {
 		var inflow, outflow types.Currency
-		for _, sci := range txn.BigFileInputs {
-			if sci.Parent.BigFileOutput.Address != sw.addr {
+		for _, bigi := range txn.BigFileInputs {
+			if bigi.Parent.BigFileOutput.Address != sw.addr {
 				continue
 			}
-			outflow = outflow.Add(sci.Parent.BigFileOutput.Value)
+			outflow = outflow.Add(bigi.Parent.BigFileOutput.Value)
 		}
 
-		for _, sco := range txn.BigFileOutputs {
-			if sco.Address != sw.addr {
+		for _, bigo := range txn.BigFileOutputs {
+			if bigo.Address != sw.addr {
 				continue
 			}
-			inflow = inflow.Add(sco.Value)
+			inflow = inflow.Add(bigo.Value)
 		}
 
 		// skip transactions that don't affect the wallet
@@ -594,23 +594,23 @@ func (sw *SingleAddressWallet) selectRedistributeUTXOs(bh uint64, outputs int, a
 	// fetch outputs currently in the pool
 	inPool := make(map[types.BigFileOutputID]bool)
 	for _, txn := range sw.cm.PoolTransactions() {
-		for _, sci := range txn.BigFileInputs {
-			inPool[sci.ParentID] = true
+		for _, bigi := range txn.BigFileInputs {
+			inPool[bigi.ParentID] = true
 		}
 	}
 	for _, txn := range sw.cm.V2PoolTransactions() {
-		for _, sci := range txn.BigFileInputs {
-			inPool[sci.Parent.ID] = true
+		for _, bigi := range txn.BigFileInputs {
+			inPool[bigi.Parent.ID] = true
 		}
 	}
 
 	// adjust the number of desired outputs for any output we encounter that is
 	// unused, matured and has the same value
 	utxos := make([]types.BigFileElement, 0, len(elements))
-	for _, sce := range elements {
-		inUse := sw.isLocked(sce.ID) || inPool[sce.ID]
-		matured := bh >= sce.MaturityHeight
-		sameValue := sce.BigFileOutput.Value.Equals(amount)
+	for _, bige := range elements {
+		inUse := sw.isLocked(bige.ID) || inPool[bige.ID]
+		matured := bh >= bige.MaturityHeight
+		sameValue := bige.BigFileOutput.Value.Equals(amount)
 
 		// adjust number of desired outputs
 		if !inUse && matured && sameValue {
@@ -619,7 +619,7 @@ func (sw *SingleAddressWallet) selectRedistributeUTXOs(bh uint64, outputs int, a
 
 		// collect usable outputs for defragging
 		if !inUse && matured && !sameValue {
-			utxos = append(utxos, sce.Share())
+			utxos = append(utxos, bige.Share())
 		}
 	}
 	// desc sort
@@ -687,8 +687,8 @@ func (sw *SingleAddressWallet) Redistribute(outputs int, amount, feePerByte type
 		// collect outputs that cover the total amount
 		var inputs []types.BigFileElement
 		want := amount.Mul64(uint64(len(txn.BigFileOutputs)))
-		for _, sce := range utxos {
-			inputs = append(inputs, sce.Share())
+		for _, bige := range utxos {
+			inputs = append(inputs, bige.Share())
 			fee := feePerInput.Mul64(uint64(len(inputs))).Add(outputFees)
 			if SumOutputs(inputs).Cmp(want.Add(fee)) > 0 {
 				break
@@ -724,13 +724,13 @@ func (sw *SingleAddressWallet) Redistribute(outputs int, amount, feePerByte type
 
 		// add the inputs
 		toSignTxn := make([]types.Hash256, 0, len(inputs))
-		for _, sce := range inputs {
-			toSignTxn = append(toSignTxn, types.Hash256(sce.ID))
+		for _, bige := range inputs {
+			toSignTxn = append(toSignTxn, types.Hash256(bige.ID))
 			txn.BigFileInputs = append(txn.BigFileInputs, types.BigFileInput{
-				ParentID:         sce.ID,
+				ParentID:         bige.ID,
 				UnlockConditions: types.StandardUnlockConditions(sw.priv.PublicKey()),
 			})
-			sw.locked[sce.ID] = time.Now().Add(sw.cfg.ReservationDuration)
+			sw.locked[bige.ID] = time.Now().Add(sw.cfg.ReservationDuration)
 		}
 		txns = append(txns, txn)
 		toSign = append(toSign, toSignTxn)
@@ -792,8 +792,8 @@ func (sw *SingleAddressWallet) RedistributeV2(outputs int, amount, feePerByte ty
 		// collect outputs that cover the total amount
 		var inputs []types.BigFileElement
 		want := amount.Mul64(uint64(len(txn.BigFileOutputs)))
-		for _, sce := range utxos {
-			inputs = append(inputs, sce.Copy())
+		for _, bige := range utxos {
+			inputs = append(inputs, bige.Copy())
 			fee := feePerInput.Mul64(uint64(len(inputs))).Add(outputFees)
 			if SumOutputs(inputs).Cmp(want.Add(fee)) > 0 {
 				break
@@ -829,12 +829,12 @@ func (sw *SingleAddressWallet) RedistributeV2(outputs int, amount, feePerByte ty
 
 		// add the inputs
 		toSignTxn := make([]int, 0, len(inputs))
-		for _, sce := range inputs {
+		for _, bige := range inputs {
 			toSignTxn = append(toSignTxn, len(txn.BigFileInputs))
 			txn.BigFileInputs = append(txn.BigFileInputs, types.V2BigFileInput{
-				Parent: sce.Move(),
+				Parent: bige.Move(),
 			})
-			sw.locked[sce.ID] = time.Now().Add(sw.cfg.ReservationDuration)
+			sw.locked[bige.ID] = time.Now().Add(sw.cfg.ReservationDuration)
 		}
 		txns = append(txns, txn)
 		toSign = append(toSign, toSignTxn)
@@ -869,20 +869,20 @@ func (sw *SingleAddressWallet) isLocked(id types.BigFileOutputID) bool {
 // IsRelevantTransaction returns true if the v1 transaction is relevant to the
 // address
 func IsRelevantTransaction(txn types.Transaction, addr types.Address) bool {
-	for _, sci := range txn.BigFileInputs {
-		if sci.UnlockConditions.UnlockHash() == addr {
+	for _, bigi := range txn.BigFileInputs {
+		if bigi.UnlockConditions.UnlockHash() == addr {
 			return true
 		}
 	}
 
-	for _, sco := range txn.BigFileOutputs {
-		if sco.Address == addr {
+	for _, bigo := range txn.BigFileOutputs {
+		if bigo.Address == addr {
 			return true
 		}
 	}
 
-	for _, sci := range txn.SiafundInputs {
-		if sci.UnlockConditions.UnlockHash() == addr {
+	for _, bigi := range txn.SiafundInputs {
+		if bigi.UnlockConditions.UnlockHash() == addr {
 			return true
 		}
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -120,11 +120,11 @@ func transactionValues(t *testing.T, wm *wallet.SingleAddressWallet, txn types.T
 		if si.UnlockConditions.UnlockHash() != addr {
 			continue
 		}
-		sce, ok := elements[si.ParentID]
+		bige, ok := elements[si.ParentID]
 		if !ok {
 			t.Fatalf("missing bigfile element %v", si.ParentID)
 		}
-		outflow = outflow.Add(sce.BigFileOutput.Value)
+		outflow = outflow.Add(bige.BigFileOutput.Value)
 	}
 
 	for _, so := range txn.BigFileOutputs {


### PR DESCRIPTION
…re to v1.0.3 in go.mod and go.sum; refactor code to replace 'sce' with 'bige' for consistency in handling BigFile elements across multiple files.